### PR TITLE
correct swashbuckle height limit

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
       "steampumpkin":99,
       "steampunk":99,
       "stonekeep":75,
-      "swashbuckle":85,
+      "swashbuckle":86,
       "temple":106,
       "test":5,
       "toro":92,


### PR DESCRIPTION
the swashbuckle height limit is currently 86, not 85.

case in point: 
![image](https://user-images.githubusercontent.com/61018569/171288507-8813d4ed-cf79-4f4b-9a81-c70301326f9e.png)
